### PR TITLE
switch to unordered_map to model memory in ILAtor

### DIFF
--- a/src/target-sc/ilator_dfs.cc
+++ b/src/target-sc/ilator_dfs.cc
@@ -102,7 +102,7 @@ void Ilator::DfsOpMemory(const ExprPtr& expr, StrBuff& buff, ExprVarMap& lut) {
   if (auto uid = asthub::GetUidExprOp(expr); uid == AstUidExprOp::kStore) {
     static const char* kMemStoreTemplate =
 #ifdef ILATOR_PRECISE_MEM
-        "tmp_memory[{address}] = {data};\n";
+        "tmp_memory[{address}.to_int()] = {data};\n";
 #else
         "tmp_memory[{address}.to_int()] = {data}.to_int();\n";
 #endif
@@ -156,7 +156,8 @@ void Ilator::DfsOpSpecial(const ExprPtr& expr, StrBuff& buff, ExprVarMap& lut) {
                    fmt::arg("memory_source", LookUp(expr->arg(0), lut)),
                    fmt::arg("address", LookUp(expr->arg(1), lut)),
 #ifdef ILATOR_PRECISE_MEM
-                   fmt::arg("mem_suffix", "")
+                  //  fmt::arg("mem_suffix", "")
+                  fmt::arg("mem_suffix", ".to_int()")
 #else
                    fmt::arg("mem_suffix", ".to_int()")
 #endif


### PR DESCRIPTION
For preciese memory modeling in ILAtor, this commit use unordered_map instead of map to reduce the access time complexity from O(logN) to O(1) on average.

Test with HLSCNN-ILA, and an average of 30% execution time reduction is observed.